### PR TITLE
Update source-url in META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,5 +4,5 @@
   "description" : "Parses CSV files, duh",
   "author"      : "Tony ODell",
   "depends"     : [ ],
-  "source-url"  : "git@github.com:tony-o/perl6-csv-parser.git"
+  "source-url"  : "git://github.com/tony-o/perl6-csv-parser.git"
 } 


### PR DESCRIPTION
Noticed your question on IRC. Here's what I was getting from 

david@deb6:~/git/modules.perl6.org/web$ echo https://raw.github.com/tony-o/perl6-csv-parser/master/META.info >META.list.local 
david@deb6:~/git/modules.perl6.org/web$ perl build-project-list.plhttps://raw.github.com/tony-o/perl6-csv-parser/master/META.info
Use of uninitialized value in concatenation (.) or string at lib/P6Project/Info.pm line 77.
 CSV::Parser
Use of uninitialized value $success in concatenation (.) or string at build-project-list.pl line 32.
ok - 
nok - 1
Invalid source-url found: git@github.com:tony-o/perl6-csv-parser.git

Hopefully works after applying this PR. Should show up in http://modules.perl6.org/ within a couple of hours.
